### PR TITLE
Feat/get computed style

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The bundle size is [currently 1.5kB](https://bundlephobia.com/result?p=color2k)
 
 ## Size comparison
 
-| lib        | size                                                  | link                                                  |
-| ---------- | ----------------------------------------------------- | ----------------------------------------------------- |
-| polished   | [11.2kB](https://bundlephobia.com/result?p=polished)  | [repo](https://github.com/styled-components/polished) |
-| chroma-js  | [13.7kB](https://bundlephobia.com/result?p=chroma-js) | [repo](https://github.com/gka/chroma.js)              |
-| color      | [7.6kB](https://bundlephobia.com/result?p=color)      | [repo](https://github.com/Qix-/color)                 |
-| tinycolor2 | [5kB](https://bundlephobia.com/result?p=tinycolor2)   | [repo](https://github.com/bgrins/TinyColor)           |
-| color2k    | [1.5kB](https://bundlephobia.com/result?p=color2k)    | 😎                                                    |
+| lib                                                       | size                                                  |
+| --------------------------------------------------------- | ----------------------------------------------------- |
+| [polished](https://github.com/styled-components/polished) | [11.2kB](https://bundlephobia.com/result?p=polished)  |
+| [chroma-js](<(https://github.com/gka/chroma.js)>)         | [13.7kB](https://bundlephobia.com/result?p=chroma-js) |
+| [color](https://github.com/Qix-/color)                    | [7.6kB](https://bundlephobia.com/result?p=color)      |
+| [tinycolor2](https://github.com/bgrins/TinyColor)         | [5kB](https://bundlephobia.com/result?p=tinycolor2)   |
+| color2k                                                   | [1.5kB](https://bundlephobia.com/result?p=color2k) 😎 |
 
 ## Installation
 
@@ -43,27 +43,25 @@ transparentize('red', 0.5);
 
 There are two secrets that keep this lib especially small:
 
-1. defer to the browser to [parse colors via canvas](https://github.com/ricokahler/color2k/blob/23589d4c6a9dc281d111f35bc2058a3fbf1bd805/packages/parse-to-rgba/src/index.ts#L63)
+1. defer to the browser to [parse colors via `getComputedStyle`](https://github.com/ricokahler/color2k/blob/63905b1ad09312cc4e06f20961c6dfb930a3ceb3/packages/parse-to-rgba/src/index.ts#L63)
 2. only support two color models as outputs, namely `rgba` and `hsla`
 
-### Why canvas?
+### Why `getComputedStyle`?
 
-The browser already has the ability to parse colors via canvas. Other color libs use javascript to parse and transform colors. The result of making the browser parse the color is the removal of any code related to parsing colors resulting in a significantly smaller bundle.
+The browser already has the ability to parse colors via `getComputedStyle`. Other color libs use javascript to parse and transform colors. The result of making the browser parse the color is the removal of any code related to parsing colors resulting in a significantly smaller bundle.
 
-Additionally, deferring to the browser for parsing colors means that this lib can parse any color that browser can parse. [This means that Apple's `display-p3` colors can be parsed with this lib in Safari.](https://github.com/ricokahler/color2k/issues/16#issuecomment-627574068)
+### Why not `getComputedStyle`?
 
-### Why not canvas?
+Using `getComputedStyle` is slower than parsing via javascript.
 
-Using canvas is slower than parsing via javascript.
+On my 2019 MacBook Pro:
 
-On my MacBook:
-
-- Canvas: 58,588 ops/sec
+- `getComputedStyle`: 594,499 ops/sec
 - JavaScript: 3,335,123 ops/sec
 
-[See here](https://jsperf.com/polished-vs-canvas/1)
+[See here](https://jsperf.com/polished-vs-canvas/3)
 
-In order to increase performance, already computed colors are [cached](https://github.com/ricokahler/color2k/blob/d33ecf6f905c17bec94cb879dedcf7b6ae5c5fae/packages/parse-to-rgba/src/index.ts#L37-L39).
+In order to increase performance, already computed colors are [cached](https://github.com/ricokahler/color2k/blob/22941f75aa9216f2a581a02da41b7fb8f18ffba4/packages/parse-to-rgba/src/index.ts#L41).
 
 ### Why only `rgba` and `hsla` as outputs?
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@color2k/node",
-  "description": "parses colors to rgba in a node-safe, non-canvas way",
+  "description": "parses colors to rgba in a node-safe, non-browser way",
   "dependencies": {},
   "private": true
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -41,7 +41,6 @@ function parseToRgbaNode(color: string): [number, number, number, number] {
     const g = parseInt(`${normalizedColor[3]}${normalizedColor[4]}`, 16);
     const b = parseInt(`${normalizedColor[5]}${normalizedColor[6]}`, 16);
     const a = parseInt(`${normalizedColor[7]}${normalizedColor[8]}`, 16) / 255;
-    if (a === 0) return [0, 0, 0, 0];
     return [r, g, b, a];
   }
 
@@ -57,7 +56,6 @@ function parseToRgbaNode(color: string): [number, number, number, number] {
     const g = parseInt(`${normalizedColor[2]}${normalizedColor[2]}`, 16);
     const b = parseInt(`${normalizedColor[3]}${normalizedColor[3]}`, 16);
     const a = parseInt(`${normalizedColor[4]}${normalizedColor[4]}`, 16) / 255;
-    if (a === 0) return [0, 0, 0, 0];
     return [r, g, b, a];
   }
 
@@ -75,7 +73,6 @@ function parseToRgbaNode(color: string): [number, number, number, number] {
     const g = parseInt(`${rgbaMatched[2]}`, 10);
     const b = parseInt(`${rgbaMatched[3]}`, 10);
     const a = parseFloat(`${rgbaMatched[4]}`);
-    if (a === 0) return [0, 0, 0, 0];
     return [r, g, b, a];
   }
 
@@ -107,7 +104,6 @@ function parseToRgbaNode(color: string): [number, number, number, number] {
     const g = parseInt(`${hslRgbMatched[2]}`, 10);
     const b = parseInt(`${hslRgbMatched[3]}`, 10);
     const a = parseFloat(`${hslaMatched[4]}`);
-    if (a === 0) return [0, 0, 0, 0];
     return [r, g, b, a];
   }
 

--- a/packages/parse-to-rgba/package.json
+++ b/packages/parse-to-rgba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@color2k/parse-to-rgba",
-  "description": "a low-level color parser that uses canvas to parse a colors",
+  "description": "a low-level color parser that uses getComputedStyle to parse a colors",
   "dependencies": {},
   "peerDependencies": {
     "@color2k/node": "*"

--- a/packages/parse-to-rgba/src/index.test.ts
+++ b/packages/parse-to-rgba/src/index.test.ts
@@ -47,11 +47,11 @@ describe('node', () => {
   });
 
   test('rgba full transparent', () => {
-    expect(parseToRgba('rgba(255, 255, 255, 0)')).toEqual([0, 0, 0, 0]);
+    expect(parseToRgba('rgba(255, 255, 255, 0)')).toEqual([255, 255, 255, 0]);
   });
 
   test('hsla full transparent', () => {
-    expect(parseToRgba('hsla(0, 100%, 100%, 0)')).toEqual([0, 0, 0, 0]);
+    expect(parseToRgba('hsla(0, 100%, 100%, 0)')).toEqual([255, 255, 255, 0]);
   });
 
   test('transparent', () => {
@@ -69,7 +69,7 @@ describe('node', () => {
 
 const browserTypes =
   // only run in CI
-  process.env.CI === 'true'
+  true
     ? ['chromium' as 'chromium', 'firefox' as 'firefox', 'webkit' as 'webkit']
     : [];
 
@@ -102,7 +102,7 @@ for (const browserType of browserTypes) {
 
     test('hex w/ alpha', async () => {
       const result = await page.evaluate("parseToRgba('#0000ffaa')");
-      expect(result).toEqual([0, 0, 255, 2 / 3]);
+      expect(result).toEqual([0, 0, 255, 0.667]);
     });
 
     test('hsl', async () => {
@@ -119,21 +119,21 @@ for (const browserType of browserTypes) {
       const result = await page.evaluate(
         "parseToRgba('rgba(255, 255, 255, 0.5)')"
       );
-      expect(result).toEqual([255, 255, 255, 128 / 255]);
+      expect(result).toEqual([255, 255, 255, 0.5]);
     });
 
     test('rgba full transparent', async () => {
       const result = await page.evaluate(
         "parseToRgba('rgba(255, 255, 230, 0)')"
       );
-      expect(result).toEqual([0, 0, 0, 0]);
+      expect(result).toEqual([255, 255, 230, 0]);
     });
 
     test('hsla full transparent', async () => {
       const result = await page.evaluate(
         "parseToRgba('hsla(0, 100%, 100%, 0)')"
       );
-      expect(result).toEqual([0, 0, 0, 0]);
+      expect(result).toEqual([255, 255, 255, 0]);
     });
 
     test('transparent', async () => {

--- a/packages/parse-to-rgba/src/index.test.ts
+++ b/packages/parse-to-rgba/src/index.test.ts
@@ -69,7 +69,7 @@ describe('node', () => {
 
 const browserTypes =
   // only run in CI
-  true
+  process.env.CI === 'true'
     ? ['chromium' as 'chromium', 'firefox' as 'firefox', 'webkit' as 'webkit']
     : [];
 

--- a/packages/parse-to-rgba/src/index.test.ts
+++ b/packages/parse-to-rgba/src/index.test.ts
@@ -146,8 +146,6 @@ for (const browserType of browserTypes) {
       try {
         await page.evaluate("parseToRgba('not real')");
       } catch {
-        // the error messages differen from browser to browser so this will
-        // have to do
         caught = true;
       }
 


### PR DESCRIPTION
Switches the canvas implementation to `getComputedStyle` because it's [waaay faster](https://jsperf.com/polished-vs-canvas/3).