### PR TITLE
docs: Slightly improve documentation

### DIFF
--- a/src/darken.ts
+++ b/src/darken.ts
@@ -5,7 +5,7 @@ import hsla from './hsla';
  * Darkens using lightness. This is equivalent to subtracting the lightness
  * from the L in HSL.
  *
- * @param amount the amount to darken, given as a decimal between 0 and 1
+ * @param amount The amount to darken, given as a decimal between 0 and 1
  */
 function darken(color: string, amount: number): string {
   const [hue, saturation, lightness, alpha] = parseToHsla(color);

--- a/src/desaturate.ts
+++ b/src/desaturate.ts
@@ -5,7 +5,7 @@ import hsla from './hsla';
  * Desaturates the input color by the given amount via subtracting from the `s`
  * in `hsla`.
  *
- * @param amount amount to desaturate, given as a decimal between 0 and 1
+ * @param amount The amount to desaturate, given as a decimal between 0 and 1
  */
 function desaturate(color: string, amount: number): string {
   const [h, s, l, a] = parseToHsla(color);

--- a/src/hasBadContrast.ts
+++ b/src/hasBadContrast.ts
@@ -8,7 +8,8 @@ const guidelines = {
 };
 
 /**
- * Returns whether or not a color has bad contrast according to a given standard
+ * Returns whether or not a color has bad contrast against 
+ * a white background according to a given standard
  */
 function hasBadContrast(
   color: string,

--- a/src/lighten.ts
+++ b/src/lighten.ts
@@ -3,7 +3,7 @@ import darken from './darken';
  * Lightens a color by a given amount. This is equivalent to
  * `darken(color, -amount)`
  *
- * @param amount the amount to darken, given as a decimal between 0 and 1
+ * @param amount The amount to darken, given as a decimal between 0 and 1
  */
 function lighten(color: string, amount: number): string {
   return darken(color, -amount);

--- a/src/opacify.ts
+++ b/src/opacify.ts
@@ -4,7 +4,7 @@ import transparentize from './transparentize';
  * Takes a color and un-transparentizes it. Equivalent to
  * `transparentize(color, -amount)`
  *
- * @param amount the amount to darken, given as a decimal between 0 and 1
+ * @param amount The amount to increase the opacity by, given as a decimal between 0 and 1
  */
 function opacify(color: string, amount: number): string {
   return transparentize(color, -amount);

--- a/src/saturate.ts
+++ b/src/saturate.ts
@@ -4,8 +4,8 @@ import desaturate from './desaturate';
  * Saturates a color by converting it to `hsl` and increasing the saturation
  * amount. Equivalent to `desaturate(color, -amount)`
  * 
- * @param color the input color
- * @param amount the amount to darken, given as a decimal between 0 and 1
+ * @param color Input color
+ * @param amount The amount to darken, given as a decimal between 0 and 1
  */
 function saturate(color: string, amount: number): string {
   return desaturate(color, -amount);

--- a/src/transparentize.ts
+++ b/src/transparentize.ts
@@ -5,7 +5,7 @@ import rgba from './rgba';
  * Takes in a color and makes it more transparent by convert to `rgba` and
  * decreasing the amount in the alpha channel.
  *
- * @param amount the amount to darken, given as a decimal between 0 and 1
+ * @param amount The amount to increase the transparency by, given as a decimal between 0 and 1
  */
 function transparentize(color: string, amount: number): string {
   const [r, g, b, a] = parseToRgba(color);


### PR DESCRIPTION
Fixes #244

Some documentation improvements:
- Fixes the description of the `amount` parameter of the opacify/transparentize functions which seem to have been copy & pasted from the `darken` function. They now read:
   - The amount to increase the opacity by, given as a decimal between 0 and 1
   - The amount to increase the transparency by, given as a decimal between 0 and 1
- More consistently capitalise the first word of parameter descriptions
- Specify that the `hasBadContrast` function bases its return value on a comparison with white

I considered adding a third param (background color) to `hasBadContrast`, but held off for now.