### PR TITLE
fix: remove the error class in favor of old school prototypes

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -31,6 +31,9 @@ async function main() {
 
   console.log('generating types…');
   await execute('npx tsc');
+  // tsc with `--allowJs` doesn't use the .d.ts in the src folder
+  // so we explicitly copy it over
+  await execute('cp ./src/ColorError.d.ts ./dist');
 
   console.log('rolling…');
   await execute('npx rollup -c');

--- a/src/ColorError.d.ts
+++ b/src/ColorError.d.ts
@@ -1,0 +1,9 @@
+/**
+ * This error is thrown if there is a color parsing error. You may use this
+ * inside of catch block with `instanceof` to ignore color paring errors.
+ */
+declare class ColorError extends Error {
+  constructor(color: string);
+}
+
+export default ColorError;

--- a/src/ColorError.js
+++ b/src/ColorError.js
@@ -1,0 +1,16 @@
+function ColorError(color) {
+  var instance = new Error(`Failed to parse color: "${color}"`);
+  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+  return instance;
+}
+ColorError.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
+});
+Object.setPrototypeOf(ColorError, Error);
+
+export default ColorError;

--- a/src/ColorError.test.ts
+++ b/src/ColorError.test.ts
@@ -1,0 +1,11 @@
+import ColorError from './ColorError';
+
+it('is an instance of error', () => {
+  const colorError = new ColorError('test');
+  expect(colorError instanceof Error).toBe(true);
+});
+
+it('can be used with instanceof', () => {
+  const colorError = new ColorError('test');
+  expect(colorError instanceof ColorError).toBe(true);
+});

--- a/src/ColorError.ts
+++ b/src/ColorError.ts
@@ -1,7 +1,0 @@
-class ColorError extends Error {
-  constructor(color: string) {
-    super(`Failed to parse color: "${color}"`);
-  }
-}
-
-export default ColorError;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "react",
     "strict": true,
     "allowSyntheticDefaultImports": true,
+    "allowJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,

--- a/website/getDocInfo.test.ts
+++ b/website/getDocInfo.test.ts
@@ -37,7 +37,8 @@ test('all of them', async () => {
     (filename) =>
       !filename.endsWith('.test.ts') &&
       filename !== 'index.ts' &&
-      filename !== 'ColorError.ts'
+      filename !== 'ColorError.js' &&
+      filename !== 'ColorError.d.ts'
   );
 
   const docs: DocInfo[] = [];


### PR DESCRIPTION
Fixes #246 

Note: I'm not sure how i'm feeling about this change. It adds some small complexity to the build and I'm not sure if how I extended the error prototype is consistent with how Babel does it.