### PR TITLE
fix: use conditional `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "chroma-js"
   ],
   "sideEffects": false,
-  "exports": "./dist/index.modern.js",
+  "exports": {
+    "import": "./dist/index.modern.js",
+    "require": "./dist/index.js"
+  },
   "main": "./dist/index.js",
   "unpkg": "./dist/index.umd.js",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
### Description

Usage with jest tests was failing for `1.2.1` due to the `exports` configuration.

This uses https://nodejs.org/api/packages.html#packages_conditional_exports to fix it.