### PR TITLE
fix(mix): return valid colors with transparent values at weight extremes

### DIFF
--- a/src/mix.test.ts
+++ b/src/mix.test.ts
@@ -51,3 +51,15 @@ test('mix blue and green', () => {
   );
   expect(mix('blue', 'green', 1)).toMatchInlineSnapshot(`"rgba(0, 128, 0, 1)"`);
 });
+
+test('mix with transparent and weight 0%', () => {
+  expect(mix('transparent', 'blue', 0)).toMatchInlineSnapshot(
+    `"rgba(0, 0, 0, 0)"`
+  );
+});
+
+test('mix with transparent and weight 100%', () => {
+  expect(mix('red', 'rgba(255, 0, 0, 0)', 100)).toMatchInlineSnapshot(
+    `"rgba(255, 0, 0, 0)"`
+  );
+});

--- a/src/mix.test.ts
+++ b/src/mix.test.ts
@@ -59,7 +59,7 @@ test('mix with transparent and weight 0%', () => {
 });
 
 test('mix with transparent and weight 100%', () => {
-  expect(mix('red', 'rgba(255, 0, 0, 0)', 100)).toMatchInlineSnapshot(
     `"rgba(255, 0, 0, 0)"`
+  expect(mix('red', 'rgba(255, 0, 0, 0)', 1)).toMatchInlineSnapshot(
   );
 });

--- a/src/mix.test.ts
+++ b/src/mix.test.ts
@@ -59,7 +59,7 @@ test('mix with transparent and weight 0%', () => {
 });
 
 test('mix with transparent and weight 100%', () => {
-    `"rgba(255, 0, 0, 0)"`
   expect(mix('red', 'rgba(255, 0, 0, 0)', 1)).toMatchInlineSnapshot(
+    `"rgba(255, 0, 0, 0)"`
   );
 });

--- a/src/mix.ts
+++ b/src/mix.ts
@@ -5,9 +5,6 @@ import rgba from './rgba';
  * Mixes two colors together. Taken from sass's implementation.
  */
 function mix(color1: string, color2: string, weight: number): string {
-  if (weight <= 0) return rgba(...parseToRgba(color1));
-  if (weight >= 1) return rgba(...parseToRgba(color2));
-
   const normalize = (n: number, index: number) =>
     // 3rd index is alpha channel which is already normalized
     index === 3 ? n : n / 255;
@@ -18,10 +15,12 @@ function mix(color1: string, color2: string, weight: number): string {
   // The formula is copied from the original Sass implementation:
   // http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method
   const alphaDelta = a2 - a1;
-  const x = weight * 2 - 1;
-  const y = x * alphaDelta === -1 ? x : x + alphaDelta;
-  const z = 1 + x * alphaDelta;
-  const weight2 = (y / z + 1) / 2.0;
+  const normalizedWeight = weight * 2 - 1;
+  const combinedWeight =
+    normalizedWeight * alphaDelta === -1
+      ? normalizedWeight
+      : normalizedWeight + alphaDelta / (1 + normalizedWeight * alphaDelta);
+  const weight2 = (combinedWeight + 1) / 2;
   const weight1 = 1 - weight2;
 
   const r = (r1 * weight1 + r2 * weight2) * 255;

--- a/src/mix.ts
+++ b/src/mix.ts
@@ -5,6 +5,9 @@ import rgba from './rgba';
  * Mixes two colors together. Taken from sass's implementation.
  */
 function mix(color1: string, color2: string, weight: number): string {
+  if (weight <= 0) return rgba(...parseToRgba(color1));
+  if (weight >= 1) return rgba(...parseToRgba(color2));
+
   const normalize = (n: number, index: number) =>
     // 3rd index is alpha channel which is already normalized
     index === 3 ? n : n / 255;


### PR DESCRIPTION
Fixes #408

Updates the algorithm to correctly handle these edge cases based on the current dart-sass implementation: https://github.com/sass/dart-sass/blob/169178af6c6414d01bc66144b437701057ff3684/lib/src/functions/color.dart#L800-L838