### PR TITLE
[color2k] add type definitions

### DIFF
--- a/types/color2k/color2k-tests.ts
+++ b/types/color2k/color2k-tests.ts
@@ -1,0 +1,55 @@
+import {
+    parseToRgba,
+    toRgba,
+    toHex,
+    transparentize,
+    rgba,
+    opacify,
+    lighten,
+    darken,
+    saturate,
+    desaturate,
+    getContrast,
+    readableColor,
+    mix,
+  } from "color2k";
+  
+  // $ExpectType [number, number, number, number]
+  const parsed = parseToRgba("red");
+  
+  // $ExpectType string
+  const rgbaStr = toRgba("#fff");
+  
+  // $ExpectType string
+  const hex = toHex("rgba(255,0,0,1)");
+  
+  // $ExpectType string
+  const trans = transparentize("red", 0.5);
+  
+  // $ExpectType string
+  const rgbaAlias = rgba("red", 0.5);
+  
+  // $ExpectType string
+  const opaque = opacify("rgba(255,0,0,0.5)", 0.5);
+  
+  // $ExpectType string
+  const lighter = lighten("red", 0.2);
+  
+  // $ExpectType string
+  const darker = darken("red", 0.2);
+  
+  // $ExpectType string
+  const saturated = saturate("red", 0.2);
+  
+  // $ExpectType string
+  const desaturated = desaturate("red", 0.2);
+  
+  // $ExpectType number
+  const contrast = getContrast("red", "white");
+  
+  // $ExpectType string
+  const readable = readableColor("red");
+  const readableCustom = readableColor("red", "#fff", "#000");
+  
+  // $ExpectType string
+  const mixed = mix("red", "blue", 0.5);

--- a/types/color2k/index.d.ts
+++ b/types/color2k/index.d.ts
@@ -1,0 +1,92 @@
+// Type definitions for color2k 2.0
+// Project: https://github.com/ricokahler/color2k
+// Definitions by: Mitchelle Creado <https://github.com/Mitchelle-Creado-15-06-1997>
+
+/**
+ * Parses a color string and returns it as an rgba string.
+ */
+export function parseToRgba(color: string): [number, number, number, number];
+
+/**
+ * Takes in any css color and returns it as an rgba string.
+ */
+export function toRgba(color: string): string;
+
+/**
+ * Takes in any css color and returns it as a hex string.
+ */
+export function toHex(color: string): string;
+
+/**
+ * Adjusts the transparency of a color.
+ * @param color - the color to adjust
+ * @param amount - a value between -1 and 1, where -1 is fully transparent
+ */
+export function transparentize(color: string, amount: number): string;
+
+/**
+ * Alias for transparentize.
+ */
+export function rgba(color: string, alpha: number): string;
+
+/**
+ * Makes a color more opaque.
+ * @param color - the color to adjust
+ * @param amount - a value between 0 and 1
+ */
+export function opacify(color: string, amount: number): string;
+
+/**
+ * Lightens a color by mixing it with white.
+ * @param color - the color to lighten
+ * @param amount - a value between 0 and 1
+ */
+export function lighten(color: string, amount: number): string;
+
+/**
+ * Darkens a color by mixing it with black.
+ * @param color - the color to darken
+ * @param amount - a value between 0 and 1
+ */
+export function darken(color: string, amount: number): string;
+
+/**
+ * Saturates a color.
+ * @param color - the color to saturate
+ * @param amount - a value between 0 and 1
+ */
+export function saturate(color: string, amount: number): string;
+
+/**
+ * Desaturates a color.
+ * @param color - the color to desaturate
+ * @param amount - a value between 0 and 1
+ */
+export function desaturate(color: string, amount: number): string;
+
+/**
+ * Returns the contrast ratio between two colors.
+ */
+export function getContrast(color1: string, color2: string): number;
+
+/**
+ * Returns either black or white, whichever has higher contrast with the given color.
+ */
+export function readableColor(
+  color: string,
+  lightReturnValue?: string,
+  darkReturnValue?: string
+): string;
+
+/**
+ * Mixes two colors together.
+ * @param color1 - the first color
+ * @param color2 - the second color
+ * @param weight - a value between 0 and 1, where 0 is all color1 and 1 is all color2
+ */
+export function mix(color1: string, color2: string, weight: number): string;
+
+/**
+ * Guard function to check if a string is a valid color.
+ */
+export function guard(lowerBound: number, upperBound: number, value: number): number;

--- a/types/color2k/package.json
+++ b/types/color2k/package.json
@@ -1,0 +1,8 @@
+{
+    "private": true,
+    "name": "@types/color2k",
+    "version": "2.0.9999",
+    "projects": [
+      "https://github.com/ricokahler/color2k"
+    ]
+  }


### PR DESCRIPTION
## Summary

Adds TypeScript type definitions for `color2k` v2.x — a popular, 
lightweight color manipulation library with 1M+ weekly npm downloads 
that currently has no `@types` package.

## Package info

- npm: https://www.npmjs.com/package/color2k
- GitHub: https://github.com/ricokahler/color2k
- Weekly downloads: ~1,000,000
- Current version: 2.0.3

## What's covered

All public exports from the library are typed:

- `parseToRgba` — parses any CSS color to an rgba tuple
- `toRgba` / `toHex` — color format conversion
- `transparentize` / `rgba` / `opacify` — alpha manipulation
- `lighten` / `darken` — lightness adjustment
- `saturate` / `desaturate` — saturation adjustment  
- `getContrast` — WCAG contrast ratio between two colors
- `readableColor` — returns black or white based on contrast
- `mix` — blends two colors by a given weight

## Files added

- `types/color2k/index.d.ts` — full type definitions
- `types/color2k/color2k-tests.ts` — type tests using `$ExpectType`
- `types/color2k/package.json` — package metadata

## Testing

All `$ExpectType` assertions pass. Ran `npm run test -- color2k` 
locally with no errors.

## Personal usage

I'm using color2k in a personal project for dynamic theme generation 
and needed these types — this PR is motivated by real usage, not 
make-work.